### PR TITLE
Update to v1.1.1

### DIFF
--- a/bin/news2motd
+++ b/bin/news2motd
@@ -94,7 +94,7 @@ def main():
     )
     cli.add_argument(
         '--motd-path',
-        help='local path to file with MOTD text message (default: {MOTD_PATH})',
+        help=f'local path to file with MOTD text message (default: {MOTD_PATH})',
         default=MOTD_PATH,
         required=False,
         type=argparse.FileType('x', encoding='UTF-8'),

--- a/src/term_rst_post/ansimotd.py
+++ b/src/term_rst_post/ansimotd.py
@@ -61,7 +61,7 @@ def accomodate_motd(body_file, head_file=None, foot_file=None, foot_link=None, w
             error_exit(f"Failed to read text file: '{part.name}'", err)
         else:
             motd_text.append(part_text)
-            logger.info(f"Added contents of '{part.name}' to MOTD text file")
+            logger.info(f"Added contents of '{part.name}' to ANSI text file")
 
     # Inject extra link between body and footer
     if foot_link:
@@ -77,7 +77,7 @@ def accomodate_motd(body_file, head_file=None, foot_file=None, foot_link=None, w
     http_urls = re.findall(r'(https?://[^\s]+)', motd_text)
     for url in http_urls:
         if len(url) > wrap_width:
-            logger.warning(f"Found a URL in MOTD longer than its width: {url} ({len(url)} char)")
+            logger.warning(f"Found a URL longer than ANSI text width: {url} ({len(url)} char)")
 
     # Format MOTD text file
     try:

--- a/src/term_rst_post/ansimotd.py
+++ b/src/term_rst_post/ansimotd.py
@@ -40,7 +40,7 @@ from term_rst_post.exit import error_exit
 logger = logging.getLogger()
 
 
-def accomodate_motd(body_file, head_file=None, foot_file=None, foot_link=None, wrap_width=70):
+def accomodate_motd(body_file, head_file=None, foot_file=None, foot_link=None, wrap_width=80):
     """
     Transform MOTD text file by: wrapping, indenting and adding header/footer
     - body_file: (file) text file with MOTD body, it will be updated
@@ -83,7 +83,7 @@ def accomodate_motd(body_file, head_file=None, foot_file=None, foot_link=None, w
     try:
         with open(body_file.name, 'w') as motd_file:
             motd_lines = motd_text.splitlines()
-            # Wrap text to 70 characters respecting spacings and ANSI escape codes
+            # Wrap text to default column width respecting spacings and ANSI escape codes
             for n, line in enumerate(motd_lines):
                 motd_lines[n : n + 1] = wrap_ansicode(line, wrap_width)
             # Indent with two spaces

--- a/src/term_rst_post/ansimotd.py
+++ b/src/term_rst_post/ansimotd.py
@@ -65,7 +65,7 @@ def accomodate_motd(body_file, head_file=None, foot_file=None, foot_link=None, w
 
     # Inject extra link between body and footer
     if foot_link:
-        part_link = f"\nMore information in {foot_link}\n"
+        part_link = f"\nMore information in\n{foot_link}\n"
         if foot_file:
             motd_text.insert(-1, part_link)
         else:

--- a/src/term_rst_post/ansimotd.py
+++ b/src/term_rst_post/ansimotd.py
@@ -73,6 +73,12 @@ def accomodate_motd(body_file, head_file=None, foot_file=None, foot_link=None, w
 
     motd_text = ''.join(motd_text)
 
+    # Check for long URLs
+    http_urls = re.findall(r'(https?://[^\s]+)', motd_text)
+    for url in http_urls:
+        if len(url) > wrap_width:
+            logger.warning(f"Found a URL in MOTD longer than its width: {url} ({len(url)} char)")
+
     # Format MOTD text file
     try:
         with open(body_file.name, 'w') as motd_file:

--- a/src/term_rst_post/version.py
+++ b/src/term_rst_post/version.py
@@ -29,4 +29,4 @@ Version of term-rst-post
 @author: Alex Domingo (Vrije Universiteit Brussel)
 """
 
-VERSION = '1.1.0'
+VERSION = '1.1.1'

--- a/tests/references/ablog_motd_wrapped_headfoot.ansi
+++ b/tests/references/ablog_motd_wrapped_headfoot.ansi
@@ -3,29 +3,28 @@
 
   [1m# Test news post with a simple paragraph[22m
 
-  [1;31;7m Warning [0;27m Lorem ipsum dolor sit amet, consectetur adipiscing elit. 
-  [4mSome text with emphasis.[24m Nulla sed orci nec orci elementum facilisis 
-  vitae at mauris. Nulla eu ultrices lectus. [1mSome text in bold.[22m Integer 
-  vitae purus vel quam laoreet fringilla vitae nec diam. Donec non 
-  aliquet nisi. Vivamus quis aliquam purus. Ut non ipsum sit amet eros 
-  imperdiet gravida at a tellus. [7m`Some literal text.`[27m Curabitur at ipsum
-  bibendum nunc tincidunt bibendum nec sed sapien. Donec ultrices nunc 
-  ligula, aliquet elementum diam tempus at. Morbi condimentum, ligula 
-  vitae venenatis aliquam, tellus lectus pulvinar est, vitae efficitur 
-  odio magna vitae lorem. Nam quam risus, pellentesque nec facilisis eu,
-  facilisis vitae justo. Curabitur a ipsum placerat libero aliquam 
-  volutpat. Proin interdum porta consequat.
+  [1;31;7m Warning [0;27m Lorem ipsum dolor sit amet, consectetur adipiscing elit. [4mSome text 
+  with emphasis.[24m Nulla sed orci nec orci elementum facilisis vitae at mauris. 
+  Nulla eu ultrices lectus. [1mSome text in bold.[22m Integer vitae purus vel quam 
+  laoreet fringilla vitae nec diam. Donec non aliquet nisi. Vivamus quis aliquam 
+  purus. Ut non ipsum sit amet eros imperdiet gravida at a tellus. [7m`Some literal 
+  text.`[27m Curabitur at ipsum bibendum nunc tincidunt bibendum nec sed sapien. Donec
+  ultrices nunc ligula, aliquet elementum diam tempus at. Morbi condimentum, 
+  ligula vitae venenatis aliquam, tellus lectus pulvinar est, vitae efficitur odio
+  magna vitae lorem. Nam quam risus, pellentesque nec facilisis eu, facilisis 
+  vitae justo. Curabitur a ipsum placerat libero aliquam volutpat. Proin interdum 
+  porta consequat.
 
-  Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla sed 
-  orci nec orci elementum facilisis vitae at mauris. Nulla eu ultrices 
-  lectus. Integer vitae purus vel quam laoreet fringilla vitae nec diam.
-  Donec non aliquet nisi. Vivamus quis aliquam purus. Ut non ipsum sit 
-  amet eros imperdiet gravida at a tellus. Curabitur at ipsum bibendum 
-  nunc tincidunt bibendum nec sed sapien. Donec ultrices nunc ligula, 
-  aliquet elementum diam tempus at. Morbi condimentum, ligula vitae 
-  venenatis aliquam, tellus lectus pulvinar est, vitae efficitur odio 
-  magna vitae lorem. Nam quam risus, pellentesque nec facilisis eu, 
-  facilisis vitae justo. Curabitur a ipsum placerat libero aliquam 
-  volutpat. Proin interdum porta consequat.
+  Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla sed orci
+  nec orci elementum facilisis vitae at mauris. Nulla eu ultrices lectus. Integer 
+  vitae 
+  purus vel quam laoreet fringilla vitae nec diam. Donec non aliquet nisi. Vivamus
+  quis aliquam purus. Ut non ipsum sit amet eros imperdiet gravida at a tellus. 
+  Curabitur at ipsum bibendum nunc tincidunt bibendum nec sed sapien. Donec 
+  ultrices nunc ligula, aliquet elementum diam tempus at. Morbi condimentum, 
+  ligula vitae venenatis aliquam, tellus lectus pulvinar est, vitae efficitur odio
+  magna vitae lorem. Nam quam risus, pellentesque nec facilisis eu, facilisis 
+  vitae justo. Curabitur a ipsum placerat libero aliquam volutpat. Proin interdum 
+  porta consequat.
   ------
   FOOTER

--- a/tests/references/ablog_motd_wrapped_headfoot_url.ansi
+++ b/tests/references/ablog_motd_wrapped_headfoot_url.ansi
@@ -3,30 +3,29 @@
 
   [1m# Test news post with a simple paragraph[22m
 
-  [1;31;7m Warning [0;27m Lorem ipsum dolor sit amet, consectetur adipiscing elit. 
-  [4mSome text with emphasis.[24m Nulla sed orci nec orci elementum facilisis 
-  vitae at mauris. Nulla eu ultrices lectus. [1mSome text in bold.[22m Integer 
-  vitae purus vel quam laoreet fringilla vitae nec diam. Donec non 
-  aliquet nisi. Vivamus quis aliquam purus. Ut non ipsum sit amet eros 
-  imperdiet gravida at a tellus. [7m`Some literal text.`[27m Curabitur at ipsum
-  bibendum nunc tincidunt bibendum nec sed sapien. Donec ultrices nunc 
-  ligula, aliquet elementum diam tempus at. Morbi condimentum, ligula 
-  vitae venenatis aliquam, tellus lectus pulvinar est, vitae efficitur 
-  odio magna vitae lorem. Nam quam risus, pellentesque nec facilisis eu,
-  facilisis vitae justo. Curabitur a ipsum placerat libero aliquam 
-  volutpat. Proin interdum porta consequat.
+  [1;31;7m Warning [0;27m Lorem ipsum dolor sit amet, consectetur adipiscing elit. [4mSome text 
+  with emphasis.[24m Nulla sed orci nec orci elementum facilisis vitae at mauris. 
+  Nulla eu ultrices lectus. [1mSome text in bold.[22m Integer vitae purus vel quam 
+  laoreet fringilla vitae nec diam. Donec non aliquet nisi. Vivamus quis aliquam 
+  purus. Ut non ipsum sit amet eros imperdiet gravida at a tellus. [7m`Some literal 
+  text.`[27m Curabitur at ipsum bibendum nunc tincidunt bibendum nec sed sapien. Donec
+  ultrices nunc ligula, aliquet elementum diam tempus at. Morbi condimentum, 
+  ligula vitae venenatis aliquam, tellus lectus pulvinar est, vitae efficitur odio
+  magna vitae lorem. Nam quam risus, pellentesque nec facilisis eu, facilisis 
+  vitae justo. Curabitur a ipsum placerat libero aliquam volutpat. Proin interdum 
+  porta consequat.
 
-  Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla sed 
-  orci nec orci elementum facilisis vitae at mauris. Nulla eu ultrices 
-  lectus. Integer vitae purus vel quam laoreet fringilla vitae nec diam.
-  Donec non aliquet nisi. Vivamus quis aliquam purus. Ut non ipsum sit 
-  amet eros imperdiet gravida at a tellus. Curabitur at ipsum bibendum 
-  nunc tincidunt bibendum nec sed sapien. Donec ultrices nunc ligula, 
-  aliquet elementum diam tempus at. Morbi condimentum, ligula vitae 
-  venenatis aliquam, tellus lectus pulvinar est, vitae efficitur odio 
-  magna vitae lorem. Nam quam risus, pellentesque nec facilisis eu, 
-  facilisis vitae justo. Curabitur a ipsum placerat libero aliquam 
-  volutpat. Proin interdum porta consequat.
+  Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla sed orci
+  nec orci elementum facilisis vitae at mauris. Nulla eu ultrices lectus. Integer 
+  vitae 
+  purus vel quam laoreet fringilla vitae nec diam. Donec non aliquet nisi. Vivamus
+  quis aliquam purus. Ut non ipsum sit amet eros imperdiet gravida at a tellus. 
+  Curabitur at ipsum bibendum nunc tincidunt bibendum nec sed sapien. Donec 
+  ultrices nunc ligula, aliquet elementum diam tempus at. Morbi condimentum, 
+  ligula vitae venenatis aliquam, tellus lectus pulvinar est, vitae efficitur odio
+  magna vitae lorem. Nam quam risus, pellentesque nec facilisis eu, facilisis 
+  vitae justo. Curabitur a ipsum placerat libero aliquam volutpat. Proin interdum 
+  porta consequat.
 
   More information in
   https://example.com/posts/year/test

--- a/tests/references/ablog_motd_wrapped_headfoot_url.ansi
+++ b/tests/references/ablog_motd_wrapped_headfoot_url.ansi
@@ -28,6 +28,7 @@
   facilisis vitae justo. Curabitur a ipsum placerat libero aliquam 
   volutpat. Proin interdum porta consequat.
 
-  More information in https://example.com/posts/year/test
+  More information in
+  https://example.com/posts/year/test
   ------
   FOOTER

--- a/tests/references/ablog_motd_wrapped_indented.ansi
+++ b/tests/references/ablog_motd_wrapped_indented.ansi
@@ -1,27 +1,26 @@
 
   [1m# Test news post with a simple paragraph[22m
 
-  [1;31;7m Warning [0;27m Lorem ipsum dolor sit amet, consectetur adipiscing elit. 
-  [4mSome text with emphasis.[24m Nulla sed orci nec orci elementum facilisis 
-  vitae at mauris. Nulla eu ultrices lectus. [1mSome text in bold.[22m Integer 
-  vitae purus vel quam laoreet fringilla vitae nec diam. Donec non 
-  aliquet nisi. Vivamus quis aliquam purus. Ut non ipsum sit amet eros 
-  imperdiet gravida at a tellus. [7m`Some literal text.`[27m Curabitur at ipsum
-  bibendum nunc tincidunt bibendum nec sed sapien. Donec ultrices nunc 
-  ligula, aliquet elementum diam tempus at. Morbi condimentum, ligula 
-  vitae venenatis aliquam, tellus lectus pulvinar est, vitae efficitur 
-  odio magna vitae lorem. Nam quam risus, pellentesque nec facilisis eu,
-  facilisis vitae justo. Curabitur a ipsum placerat libero aliquam 
-  volutpat. Proin interdum porta consequat.
+  [1;31;7m Warning [0;27m Lorem ipsum dolor sit amet, consectetur adipiscing elit. [4mSome text 
+  with emphasis.[24m Nulla sed orci nec orci elementum facilisis vitae at mauris. 
+  Nulla eu ultrices lectus. [1mSome text in bold.[22m Integer vitae purus vel quam 
+  laoreet fringilla vitae nec diam. Donec non aliquet nisi. Vivamus quis aliquam 
+  purus. Ut non ipsum sit amet eros imperdiet gravida at a tellus. [7m`Some literal 
+  text.`[27m Curabitur at ipsum bibendum nunc tincidunt bibendum nec sed sapien. Donec
+  ultrices nunc ligula, aliquet elementum diam tempus at. Morbi condimentum, 
+  ligula vitae venenatis aliquam, tellus lectus pulvinar est, vitae efficitur odio
+  magna vitae lorem. Nam quam risus, pellentesque nec facilisis eu, facilisis 
+  vitae justo. Curabitur a ipsum placerat libero aliquam volutpat. Proin interdum 
+  porta consequat.
 
-  Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla sed 
-  orci nec orci elementum facilisis vitae at mauris. Nulla eu ultrices 
-  lectus. Integer vitae purus vel quam laoreet fringilla vitae nec diam.
-  Donec non aliquet nisi. Vivamus quis aliquam purus. Ut non ipsum sit 
-  amet eros imperdiet gravida at a tellus. Curabitur at ipsum bibendum 
-  nunc tincidunt bibendum nec sed sapien. Donec ultrices nunc ligula, 
-  aliquet elementum diam tempus at. Morbi condimentum, ligula vitae 
-  venenatis aliquam, tellus lectus pulvinar est, vitae efficitur odio 
-  magna vitae lorem. Nam quam risus, pellentesque nec facilisis eu, 
-  facilisis vitae justo. Curabitur a ipsum placerat libero aliquam 
-  volutpat. Proin interdum porta consequat.
+  Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla sed orci
+  nec orci elementum facilisis vitae at mauris. Nulla eu ultrices lectus. Integer 
+  vitae 
+  purus vel quam laoreet fringilla vitae nec diam. Donec non aliquet nisi. Vivamus
+  quis aliquam purus. Ut non ipsum sit amet eros imperdiet gravida at a tellus. 
+  Curabitur at ipsum bibendum nunc tincidunt bibendum nec sed sapien. Donec 
+  ultrices nunc ligula, aliquet elementum diam tempus at. Morbi condimentum, 
+  ligula vitae venenatis aliquam, tellus lectus pulvinar est, vitae efficitur odio
+  magna vitae lorem. Nam quam risus, pellentesque nec facilisis eu, facilisis 
+  vitae justo. Curabitur a ipsum placerat libero aliquam volutpat. Proin interdum 
+  porta consequat.

--- a/tests/references/ablog_motd_wrapped_indented_url.ansi
+++ b/tests/references/ablog_motd_wrapped_indented_url.ansi
@@ -1,30 +1,29 @@
 
   [1m# Test news post with a simple paragraph[22m
 
-  [1;31;7m Warning [0;27m Lorem ipsum dolor sit amet, consectetur adipiscing elit. 
-  [4mSome text with emphasis.[24m Nulla sed orci nec orci elementum facilisis 
-  vitae at mauris. Nulla eu ultrices lectus. [1mSome text in bold.[22m Integer 
-  vitae purus vel quam laoreet fringilla vitae nec diam. Donec non 
-  aliquet nisi. Vivamus quis aliquam purus. Ut non ipsum sit amet eros 
-  imperdiet gravida at a tellus. [7m`Some literal text.`[27m Curabitur at ipsum
-  bibendum nunc tincidunt bibendum nec sed sapien. Donec ultrices nunc 
-  ligula, aliquet elementum diam tempus at. Morbi condimentum, ligula 
-  vitae venenatis aliquam, tellus lectus pulvinar est, vitae efficitur 
-  odio magna vitae lorem. Nam quam risus, pellentesque nec facilisis eu,
-  facilisis vitae justo. Curabitur a ipsum placerat libero aliquam 
-  volutpat. Proin interdum porta consequat.
+  [1;31;7m Warning [0;27m Lorem ipsum dolor sit amet, consectetur adipiscing elit. [4mSome text 
+  with emphasis.[24m Nulla sed orci nec orci elementum facilisis vitae at mauris. 
+  Nulla eu ultrices lectus. [1mSome text in bold.[22m Integer vitae purus vel quam 
+  laoreet fringilla vitae nec diam. Donec non aliquet nisi. Vivamus quis aliquam 
+  purus. Ut non ipsum sit amet eros imperdiet gravida at a tellus. [7m`Some literal 
+  text.`[27m Curabitur at ipsum bibendum nunc tincidunt bibendum nec sed sapien. Donec
+  ultrices nunc ligula, aliquet elementum diam tempus at. Morbi condimentum, 
+  ligula vitae venenatis aliquam, tellus lectus pulvinar est, vitae efficitur odio
+  magna vitae lorem. Nam quam risus, pellentesque nec facilisis eu, facilisis 
+  vitae justo. Curabitur a ipsum placerat libero aliquam volutpat. Proin interdum 
+  porta consequat.
 
-  Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla sed 
-  orci nec orci elementum facilisis vitae at mauris. Nulla eu ultrices 
-  lectus. Integer vitae purus vel quam laoreet fringilla vitae nec diam.
-  Donec non aliquet nisi. Vivamus quis aliquam purus. Ut non ipsum sit 
-  amet eros imperdiet gravida at a tellus. Curabitur at ipsum bibendum 
-  nunc tincidunt bibendum nec sed sapien. Donec ultrices nunc ligula, 
-  aliquet elementum diam tempus at. Morbi condimentum, ligula vitae 
-  venenatis aliquam, tellus lectus pulvinar est, vitae efficitur odio 
-  magna vitae lorem. Nam quam risus, pellentesque nec facilisis eu, 
-  facilisis vitae justo. Curabitur a ipsum placerat libero aliquam 
-  volutpat. Proin interdum porta consequat.
+  Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla sed orci
+  nec orci elementum facilisis vitae at mauris. Nulla eu ultrices lectus. Integer 
+  vitae 
+  purus vel quam laoreet fringilla vitae nec diam. Donec non aliquet nisi. Vivamus
+  quis aliquam purus. Ut non ipsum sit amet eros imperdiet gravida at a tellus. 
+  Curabitur at ipsum bibendum nunc tincidunt bibendum nec sed sapien. Donec 
+  ultrices nunc ligula, aliquet elementum diam tempus at. Morbi condimentum, 
+  ligula vitae venenatis aliquam, tellus lectus pulvinar est, vitae efficitur odio
+  magna vitae lorem. Nam quam risus, pellentesque nec facilisis eu, facilisis 
+  vitae justo. Curabitur a ipsum placerat libero aliquam volutpat. Proin interdum 
+  porta consequat.
 
   More information in
   https://example.com/posts/year/test

--- a/tests/references/ablog_motd_wrapped_indented_url.ansi
+++ b/tests/references/ablog_motd_wrapped_indented_url.ansi
@@ -26,4 +26,5 @@
   facilisis vitae justo. Curabitur a ipsum placerat libero aliquam 
   volutpat. Proin interdum porta consequat.
 
-  More information in https://example.com/posts/year/test
+  More information in
+  https://example.com/posts/year/test


### PR DESCRIPTION
Changelog:
* fix help message of `news2motd`
* wrap MOTD to 80 characters by default
* inject link URL in MOTD after a new line
* warn about URLs in the MOTD that are longer than its length